### PR TITLE
added multi-threaded scanning running clamscan as a daemon

### DIFF
--- a/clamd-reload.sh
+++ b/clamd-reload.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/clamdscan --reload

--- a/template.json
+++ b/template.json
@@ -22,17 +22,17 @@
       "Description": "A list of subnets (should be either public or using a S3 VPC endpoint)",
       "Type": "List<AWS::EC2::Subnet::Id>"
     },
-	"AssignPublicIPParameter": {
-	  "Description": "Assign a public IP to instances. If this is set to false, ensure your instances have access to the internet through a NAT Host/Gateway.",
-	  "Type": "String",
-	  "Default": "true",
-	  "AllowedValues": ["true", "false"]
-	},
-	"NATSecurityGroupParameter": {
-		"Description": "If AssignPublicIP is set to false, select the security group that your NAT Host or Gateway is in (usually named 'Default'), otherwise the instances won't be able to reach the internet. If AssignPublicIP is set to true, this parameter is ignored.",
-		"Type": "AWS::EC2::SecurityGroup::Id",
-		"Default": "AWS::NoValue"
-	},
+    "AssignPublicIPParameter": {
+      "Description": "Assign a public IP to instances. If this is set to false, ensure your instances have access to the internet through a NAT Host/Gateway.",
+      "Type": "String",
+      "Default": "true",
+      "AllowedValues": ["true", "false"]
+    },
+    "NATSecurityGroupParameter": {
+        "Description": "If AssignPublicIP is set to false, select the security group that your NAT Host or Gateway is in (usually named 'Default'), otherwise the instances won't be able to reach the internet. If AssignPublicIP is set to true, this parameter is ignored.",
+        "Type": "AWS::EC2::SecurityGroup::Id",
+        "Default": "AWS::NoValue"
+    },
     "InstanceTypeParameter": {
       "Description": "Specifies the instance type of the EC2 instance",
       "Type": "String",
@@ -58,26 +58,26 @@
     }
   },
   "Metadata": {
-	"AWS::CloudFormation::Interface": {
-	  "ParameterGroups": [
-	    {
-		  "Label": {"default": "Instance Configuration"},
-		  "Parameters": ["InstanceTypeParameter", "BlockDeviceMappingsParameter", "KeyNameParameter"]
-		},
-	    {
-		  "Label": {"default": "Network Configuration"},
-		  "Parameters": ["VPCParameter", "SubnetsParameter", "AssignPublicIPParameter", "NATSecurityGroupParameter"]
-		},
-	    {
-		  "Label": {"default": "Auto-scaling Configuration"},
-		  "Parameters": ["AutoScalingMinSizeParameter", "AutoScalingMaxSizeParameter"]
-		},
-		{
-		  "Label": {"default": "ClamAV Configuration"},
-		  "Parameters": ["DeleteInfectedFilesParameter"]
-		}
-	  ]
-	}
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {"default": "Instance Configuration"},
+          "Parameters": ["InstanceTypeParameter", "BlockDeviceMappingsParameter", "KeyNameParameter"]
+        },
+        {
+          "Label": {"default": "Network Configuration"},
+          "Parameters": ["VPCParameter", "SubnetsParameter", "AssignPublicIPParameter", "NATSecurityGroupParameter"]
+        },
+        {
+          "Label": {"default": "Auto-scaling Configuration"},
+          "Parameters": ["AutoScalingMinSizeParameter", "AutoScalingMaxSizeParameter"]
+        },
+        {
+          "Label": {"default": "ClamAV Configuration"},
+          "Parameters": ["DeleteInfectedFilesParameter"]
+        }
+      ]
+    }
   },
   "Conditions": {
     "HasKeyNameParameter": {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "KeyNameParameter"}]}]},
@@ -422,7 +422,7 @@
                 "mode": "000644",
                 "owner": "root",
                 "group": "root"
-			  }
+              }
             },
             "commands": {
               "a_enable_freshclam_cron": {

--- a/template.json
+++ b/template.json
@@ -81,7 +81,7 @@
   },
   "Conditions": {
     "HasKeyNameParameter": {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "KeyNameParameter"}]}]},
-	"HasNATHostGateway": {"Fn::And": [{"Fn::Not": [{"Fn::Equals": ["", {"Ref": "NATSecurityGroupParameter"}]}]},{"Fn::Not": [{"Fn::Equals": ["true", {"Ref": "AssignPublicIPParameter"}]}]}]}
+    "HasNATHostGateway": {"Fn::And": [{"Fn::Not": [{"Fn::Equals": ["", {"Ref": "NATSecurityGroupParameter"}]}]},{"Fn::Not": [{"Fn::Equals": ["true", {"Ref": "AssignPublicIPParameter"}]}]}]}
   },
   "Mappings": {
     "RegionMap": {
@@ -328,7 +328,7 @@
               "rubygems": {
                 "aws-sdk": ["2.2.29"],
                 "daemons": ["1.2.3"],
-				"rubysl-securerandom": ["2.0.0"]
+                "rubysl-securerandom": ["2.0.0"]
               }
             },
             "sources": {
@@ -415,10 +415,10 @@
                   "runas=root", "\n"
                 ]]}
               },
-			  "/etc/clamd.conf": {
-				"content": {"Fn::Join": ["", [
-				  "LocalSocket /var/run/clamd.scan/clamd.sock"
-				]]},
+              "/etc/clamd.conf": {
+                "content": {"Fn::Join": ["", [
+                  "LocalSocket /var/run/clamd.scan/clamd.sock"
+                ]]},
                 "mode": "000644",
                 "owner": "root",
                 "group": "root"
@@ -431,9 +431,9 @@
               "b_enable_freshclam": {
                 "command": "sed -i 's/Example/#Example/g' /etc/freshclam.conf"
               },
-			  "c_enable_clamd_scan": {
-			    "command": "sed -i 's/Example/#Example/g;s/#LocalSocket /LocalSocket /g' /etc/clamd.d/scan.conf"
-			  },
+              "c_enable_clamd_scan": {
+                "command": "sed -i 's/Example/#Example/g;s/#LocalSocket /LocalSocket /g' /etc/clamd.d/scan.conf"
+              },
               "d_symlink_app_dir": {
                 "command": "ln -s /opt/aws-s3-virusscan-master /opt/aws-s3-virusscan",
                 "test": "test ! -e /opt/aws-s3-virusscan"
@@ -450,10 +450,10 @@
                 "command": "chmod +x s3-virusscan",
                 "cwd": "/opt/aws-s3-virusscan"
               },
-			  "h_chmod_clamd_reload": {
-			    "command": "chmod +x clamd-reload.sh",
+              "h_chmod_clamd_reload": {
+                "command": "chmod +x clamd-reload.sh",
                 "cwd": "/opt/aws-s3-virusscan"
-			  },
+              },
               "i_update_clamav_db": {
                 "command": "freshclam"
               }
@@ -479,13 +479,13 @@
                   "files": ["/opt/aws-s3-virusscan-master/s3-virusscan.conf"],
                   "sources": ["/opt"]
                 },
-				"clamd.scan": {
-				  "enabled": "true",
-				  "ensureRunning": "true",
-				  "packages": {
-					"yum": ["clamd"]
-				  }
-				}
+                "clamd.scan": {
+                  "enabled": "true",
+                  "ensureRunning": "true",
+                  "packages": {
+                    "yum": ["clamd"]
+                  }
+                }
               }
             }
           }
@@ -494,7 +494,7 @@
       "Properties": {
         "KeyName": {"Fn::If": ["HasKeyNameParameter", {"Ref": "KeyNameParameter"}, {"Ref": "AWS::NoValue"}]},
         "EbsOptimized": false,
-		"AssociatePublicIpAddress": { "Ref":"AssignPublicIPParameter" },
+        "AssociatePublicIpAddress": { "Ref":"AssignPublicIPParameter" },
         "BlockDeviceMappings": [{
           "DeviceName": "/dev/xvda",
           "Ebs": {

--- a/template.json
+++ b/template.json
@@ -528,7 +528,7 @@
           "ToPort": 22
         }],
         "VpcId": {"Ref": "VPCParameter"}
-	  }
-	}
+      }
+    }
   }
 }

--- a/template.json
+++ b/template.json
@@ -302,7 +302,7 @@
               }
             },
             "sources": {
-              "/opt": "https://github.com/cmilam87/aws-s3-virusscan/archive/master.zip"
+              "/opt": "https://github.com/widdix/aws-s3-virusscan/archive/master.zip"
             },
             "files": {
               "/etc/awslogs/awslogs.conf": {

--- a/template.json
+++ b/template.json
@@ -22,6 +22,10 @@
       "Description": "A list of subnets (should be either public or using a S3 VPC endpoint)",
       "Type": "List<AWS::EC2::Subnet::Id>"
     },
+	"SecurityGroupParameter":{
+		"Description": "Default security group",
+		"Type": "AWS::EC2::SecurityGroup::Id"
+	},
     "InstanceTypeParameter": {
       "Description": "Specifies the instance type of the EC2 instance",
       "Type": "String",
@@ -293,11 +297,12 @@
               },
               "rubygems": {
                 "aws-sdk": ["2.2.29"],
-                "daemons": ["1.2.3"]
+                "daemons": ["1.2.3"],
+				"rubysl-securerandom": ["2.0.0"]
               }
             },
             "sources": {
-              "/opt": "https://github.com/widdix/aws-s3-virusscan/archive/master.zip"
+              "/opt": "https://github.com/cmilam87/aws-s3-virusscan/archive/master.zip"
             },
             "files": {
               "/etc/awslogs/awslogs.conf": {
@@ -379,7 +384,15 @@
                   "action=/opt/aws/bin/cfn-init --verbose --stack=", {"Ref": "AWS::StackName"}, " --region=", {"Ref": "AWS::Region"}, " --resource=ScanLaunchConfiguration", "\n",
                   "runas=root", "\n"
                 ]]}
-              }
+              },
+			  "/etc/clamd.conf": {
+				"content": {"Fn::Join": ["", [
+				  "LocalSocket /var/run/clamd.scan/clamd.sock"
+				]]},
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+			  }
             },
             "commands": {
               "a_enable_freshclam_cron": {
@@ -388,23 +401,30 @@
               "b_enable_freshclam": {
                 "command": "sed -i 's/Example/#Example/g' /etc/freshclam.conf"
               },
-              "c_symlink_app_dir": {
+			  "c_enable_clamd_scan": {
+			    "command": "sed -i 's/Example/#Example/g;s/#LocalSocket /LocalSocket /g' /etc/clamd.d/scan.conf"
+			  },
+              "d_symlink_app_dir": {
                 "command": "ln -s /opt/aws-s3-virusscan-master /opt/aws-s3-virusscan",
                 "test": "test ! -e /opt/aws-s3-virusscan"
               },
-              "d_symlink_app_initd": {
+              "e_symlink_app_initd": {
                 "command": "ln -s /opt/aws-s3-virusscan/s3-virusscan /etc/init.d/s3-virusscan",
                 "test": "test ! -e /etc/init.d/s3-virusscan"
               },
-              "e_chmod_app_ruby": {
+              "f_chmod_app_ruby": {
                 "command": "chmod +x *.rb",
                 "cwd": "/opt/aws-s3-virusscan"
               },
-              "f_chmod_app_initd": {
+              "g_chmod_app_initd": {
                 "command": "chmod +x s3-virusscan",
                 "cwd": "/opt/aws-s3-virusscan"
               },
-              "g_update_clamav_db": {
+			  "h_chmod_clamd_reload": {
+			    "command": "chmod +x clamd-reload.sh",
+                "cwd": "/opt/aws-s3-virusscan"
+			  },
+              "i_update_clamav_db": {
                 "command": "freshclam"
               }
             },
@@ -428,7 +448,14 @@
                   "ensureRunning": "true",
                   "files": ["/opt/aws-s3-virusscan-master/s3-virusscan.conf"],
                   "sources": ["/opt"]
-                }
+                },
+				"clamd.scan": {
+				  "enabled": "true",
+				  "ensureRunning": "true",
+				  "packages": {
+					"yum": ["clamd"]
+				  }
+				}
               }
             }
           }
@@ -436,7 +463,6 @@
       },
       "Properties": {
         "KeyName": {"Fn::If": ["HasKeyNameParameter", {"Ref": "KeyNameParameter"}, {"Ref": "AWS::NoValue"}]},
-        "AssociatePublicIpAddress": true,
         "EbsOptimized": false,
         "BlockDeviceMappings": [{
           "DeviceName": "/dev/xvda",
@@ -448,29 +474,12 @@
         "IamInstanceProfile": {"Ref": "ScanInstanceProfile"},
         "ImageId": {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]},
         "InstanceType": {"Ref": "InstanceTypeParameter"},
-        "SecurityGroups": [{"Ref": "ScanSecurityGroup"}],
+        "SecurityGroups": [{"Ref": "SecurityGroupParameter"}],
         "UserData": {"Fn::Base64": {"Fn::Join": ["", [
           "#!/bin/bash -x", "\n",
           "/opt/aws/bin/cfn-init --verbose --stack=", {"Ref": "AWS::StackName"}, " --region=", {"Ref": "AWS::Region"}, " --resource=ScanLaunchConfiguration", "\n",
           "/opt/aws/bin/cfn-signal --exit-code=$? --stack=", {"Ref": "AWS::StackName"}, " --region=", {"Ref": "AWS::Region"}, " --resource=ScanAutoScalingGroup", "\n"
         ]]}}
-      }
-    },
-    "ScanSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "S3 VirusScan",
-        "SecurityGroupEgress": [{
-          "IpProtocol": "-1",
-          "CidrIp": "0.0.0.0/0"
-        }],
-        "SecurityGroupIngress": [{
-          "CidrIp": "0.0.0.0/0",
-          "FromPort": 22,
-          "IpProtocol": "tcp",
-          "ToPort": 22
-        }],
-        "VpcId": {"Ref": "VPCParameter"}
       }
     }
   }

--- a/template.json
+++ b/template.json
@@ -513,21 +513,21 @@
         ]]}}
       }
     },
-	"ScanSecurityGroup": {
-	  "Type": "AWS::EC2::SecurityGroup",
-	  "Properties": {
-	    "GroupDescription": "S3 VirusScan",
-	    "SecurityGroupEgress": [{
-	      "IpProtocol": "-1",
-	      "CidrIp": "0.0.0.0/0"
-	    }],
-	    "SecurityGroupIngress": [{
-	      "CidrIp": "0.0.0.0/0",
-	      "FromPort": 22,
-	      "IpProtocol": "tcp",
-	      "ToPort": 22
-	    }],
-	    "VpcId": {"Ref": "VPCParameter"}
+    "ScanSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "S3 VirusScan",
+        "SecurityGroupEgress": [{
+          "IpProtocol": "-1",
+          "CidrIp": "0.0.0.0/0"
+        }],
+        "SecurityGroupIngress": [{
+          "CidrIp": "0.0.0.0/0",
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "ToPort": 22
+        }],
+        "VpcId": {"Ref": "VPCParameter"}
 	  }
 	}
   }

--- a/template.json
+++ b/template.json
@@ -22,9 +22,16 @@
       "Description": "A list of subnets (should be either public or using a S3 VPC endpoint)",
       "Type": "List<AWS::EC2::Subnet::Id>"
     },
-	"SecurityGroupParameter":{
-		"Description": "Default security group",
-		"Type": "AWS::EC2::SecurityGroup::Id"
+	"AssignPublicIPParameter": {
+	  "Description": "Assign a public IP to instances. If this is set to false, ensure your instances have access to the internet through a NAT Host/Gateway.",
+	  "Type": "String",
+	  "Default": "true",
+	  "AllowedValues": ["true", "false"]
+	},
+	"NATSecurityGroupParameter": {
+		"Description": "If AssignPublicIP is set to false, select the security group that your NAT Host or Gateway is in (usually named 'Default'), otherwise the instances won't be able to reach the internet. If AssignPublicIP is set to true, this parameter is ignored.",
+		"Type": "AWS::EC2::SecurityGroup::Id",
+		"Default": "AWS::NoValue"
 	},
     "InstanceTypeParameter": {
       "Description": "Specifies the instance type of the EC2 instance",
@@ -50,8 +57,31 @@
       "MaxValue": "512"
     }
   },
+  "Metadata": {
+	"AWS::CloudFormation::Interface": {
+	  "ParameterGroups": [
+	    {
+		  "Label": {"default": "Instance Configuration"},
+		  "Parameters": ["InstanceTypeParameter", "BlockDeviceMappingsParameter", "KeyNameParameter"]
+		},
+	    {
+		  "Label": {"default": "Network Configuration"},
+		  "Parameters": ["VPCParameter", "SubnetsParameter", "AssignPublicIPParameter", "NATSecurityGroupParameter"]
+		},
+	    {
+		  "Label": {"default": "Auto-scaling Configuration"},
+		  "Parameters": ["AutoScalingMinSizeParameter", "AutoScalingMaxSizeParameter"]
+		},
+		{
+		  "Label": {"default": "ClamAV Configuration"},
+		  "Parameters": ["DeleteInfectedFilesParameter"]
+		}
+	  ]
+	}
+  },
   "Conditions": {
-    "HasKeyNameParameter": {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "KeyNameParameter"}]}]}
+    "HasKeyNameParameter": {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "KeyNameParameter"}]}]},
+	"HasNATHostGateway": {"Fn::And": [{"Fn::Not": [{"Fn::Equals": ["", {"Ref": "NATSecurityGroupParameter"}]}]},{"Fn::Not": [{"Fn::Equals": ["true", {"Ref": "AssignPublicIPParameter"}]}]}]}
   },
   "Mappings": {
     "RegionMap": {
@@ -464,6 +494,7 @@
       "Properties": {
         "KeyName": {"Fn::If": ["HasKeyNameParameter", {"Ref": "KeyNameParameter"}, {"Ref": "AWS::NoValue"}]},
         "EbsOptimized": false,
+		"AssociatePublicIpAddress": { "Ref":"AssignPublicIPParameter" },
         "BlockDeviceMappings": [{
           "DeviceName": "/dev/xvda",
           "Ebs": {
@@ -474,13 +505,30 @@
         "IamInstanceProfile": {"Ref": "ScanInstanceProfile"},
         "ImageId": {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]},
         "InstanceType": {"Ref": "InstanceTypeParameter"},
-        "SecurityGroups": [{"Ref": "SecurityGroupParameter"}],
+        "SecurityGroups": [{"Ref": "ScanSecurityGroup"},{"Fn::If": ["HasNATHostGateway", {"Ref": "NATSecurityGroupParameter"}, {"Ref":"AWS::NoValue"}]}],
         "UserData": {"Fn::Base64": {"Fn::Join": ["", [
           "#!/bin/bash -x", "\n",
           "/opt/aws/bin/cfn-init --verbose --stack=", {"Ref": "AWS::StackName"}, " --region=", {"Ref": "AWS::Region"}, " --resource=ScanLaunchConfiguration", "\n",
           "/opt/aws/bin/cfn-signal --exit-code=$? --stack=", {"Ref": "AWS::StackName"}, " --region=", {"Ref": "AWS::Region"}, " --resource=ScanAutoScalingGroup", "\n"
         ]]}}
       }
-    }
+    },
+	"ScanSecurityGroup": {
+	  "Type": "AWS::EC2::SecurityGroup",
+	  "Properties": {
+	    "GroupDescription": "S3 VirusScan",
+	    "SecurityGroupEgress": [{
+	      "IpProtocol": "-1",
+	      "CidrIp": "0.0.0.0/0"
+	    }],
+	    "SecurityGroupIngress": [{
+	      "CidrIp": "0.0.0.0/0",
+	      "FromPort": 22,
+	      "IpProtocol": "tcp",
+	      "ToPort": 22
+	    }],
+	    "VpcId": {"Ref": "VPCParameter"}
+	  }
+	}
   }
 }

--- a/worker.rb
+++ b/worker.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'uri'
 require 'yaml'
 require 'syslog/logger'
+require 'securerandom'
 
 log = Syslog::Logger.new 's3-virusscan'
 conf = YAML::load_file(__dir__ + '/s3-virusscan.conf')
@@ -17,60 +18,54 @@ poller = Aws::SQS::QueuePoller.new(conf['queue'])
 
 log.info "s3-virusscan started"
 
-poller.poll do |msg|
-  body = JSON.parse(msg.body)
-  if body.key?('Records')
-    body['Records'].each do |record|
-      bucket = record['s3']['bucket']['name']
-      key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
-      log.debug "scanning s3://#{bucket}/#{key}..."
-      begin
-        s3.get_object(
-          response_target: '/tmp/target',
-          bucket: bucket,
-          key: key
-        )
-      rescue Aws::S3::Errors::NoSuchKey
-        log.debug "s3://#{bucket}/#{key} does no longer exist"
-        next
-      end
-      if system('clamscan /tmp/target')
-        log.debug "s3://#{bucket}/#{key} was scanned without findings"
-      else
-        if conf['delete']
-          log.error "s3://#{bucket}/#{key} is infected, deleting..."
-          sns.publish(
-            topic_arn: conf['topic'],
-            message: "s3://#{bucket}/#{key} is infected, deleting...",
-            subject: "s3-virusscan s3://#{bucket}",
-            message_attributes: {
-              "key" => {
-                data_type: "String",
-                string_value: "s3://#{bucket}/#{key}"
+poller.poll(max_number_of_messages:10) do |messages|
+  messages.each do |msg|
+    body = JSON.parse(msg.body)
+    if body.key?('Records')
+      body['Records'].each do |record|
+        bucket = record['s3']['bucket']['name']
+        key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
+	    Thread.new {
+	      fileName = "/tmp/#{SecureRandom.uuid}"
+	  	  log.debug "scanning s3://#{bucket}/#{key}..."
+          begin
+            s3.get_object(
+              response_target: fileName,
+              bucket: bucket,
+              key: key
+            )
+          rescue Aws::S3::Errors::NoSuchKey
+            log.debug "s3://#{bucket}/#{key} does no longer exist"
+            next
+          end
+    
+	  	  if system("clamdscan #{fileName}")
+	  	    log.debug "s3://#{bucket}/#{key} was scanned without findings"
+	  	  else
+	  	    delete = conf['delete']
+	  	    message = "s3://#{bucket}/#{key} is infected#{delete ? ", deleting..." : ""}"
+	  	    sns.publish(
+              topic_arn: conf['topic'],
+              message: message,
+              subject: "s3-virusscan s3://#{bucket}",
+              message_attributes: {
+                "key" => {
+                  data_type: "String",
+                  string_value: "s3://#{bucket}/#{key}"
+                }
               }
-            }
-          )
-          s3.delete_object(
-            bucket: bucket,
-            key: key
-          )
-          log.error "s3://#{bucket}/#{key} was deleted"
-        else
-          log.error "s3://#{bucket}/#{key} is infected"
-          sns.publish(
-            topic_arn: conf['topic'],
-            message: "s3://#{bucket}/#{key} is infected",
-            subject: "s3-virusscan s3://#{bucket}",
-            message_attributes: {
-              "key" => {
-                data_type: "String",
-                string_value: "s3://#{bucket}/#{key}"
-              }
-            }
-          )
-        end
+            )
+	  	    if delete
+	  		  s3.delete_object(
+                bucket: bucket,
+                key: key
+              )
+              log.error "s3://#{bucket}/#{key} was deleted"
+	  	    end
+	  	  end
+	  	  system("rm #{fileName}")
+	    }
       end
-      system('rm /tmp/target')
     end
   end
 end

--- a/worker.rb
+++ b/worker.rb
@@ -25,9 +25,9 @@ poller.poll(max_number_of_messages:10) do |messages|
       body['Records'].each do |record|
         bucket = record['s3']['bucket']['name']
         key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
-	    Thread.new {
-	      fileName = "/tmp/#{SecureRandom.uuid}"
-	  	  log.debug "scanning s3://#{bucket}/#{key}..."
+        Thread.new {
+          fileName = "/tmp/#{SecureRandom.uuid}"
+          log.debug "scanning s3://#{bucket}/#{key}..."
           begin
             s3.get_object(
               response_target: fileName,
@@ -39,12 +39,12 @@ poller.poll(max_number_of_messages:10) do |messages|
             next
           end
     
-	  	  if system("clamdscan #{fileName}")
-	  	    log.debug "s3://#{bucket}/#{key} was scanned without findings"
-	  	  else
-	  	    delete = conf['delete']
-	  	    message = "s3://#{bucket}/#{key} is infected#{delete ? ", deleting..." : ""}"
-	  	    sns.publish(
+          if system("clamdscan #{fileName}")
+            log.debug "s3://#{bucket}/#{key} was scanned without findings"
+          else
+            delete = conf['delete']
+            message = "s3://#{bucket}/#{key} is infected#{delete ? ", deleting..." : ""}"
+            sns.publish(
               topic_arn: conf['topic'],
               message: message,
               subject: "s3-virusscan s3://#{bucket}",
@@ -55,16 +55,16 @@ poller.poll(max_number_of_messages:10) do |messages|
                 }
               }
             )
-	  	    if delete
-	  		  s3.delete_object(
+            if delete
+              s3.delete_object(
                 bucket: bucket,
                 key: key
               )
               log.error "s3://#{bucket}/#{key} was deleted"
-	  	    end
-	  	  end
-	  	  system("rm #{fileName}")
-	    }
+            end
+          end
+          system("rm #{fileName}")
+        }
       end
     end
   end


### PR DESCRIPTION
For the cloud formation template, I changed the security group to be a parameter and removed the need for a public IP address, although it could also be changed to a parameter. The reason being that I don't want my scanning machines directly exposed to the internet. This way I can put them in a private network and their traffic will go through a NAT host or gateway.

Also note that I had to change the sources in the AWS::CloudFormation::Init section to point at my repo to get the new worker.rb file. This can be changed once merged.

With my limited testing I was able to go through about 15 files per minute vs about 1 per minute with 1 instance. File sizes ranged from 1Kb to 10Mb.
