### PR TITLE
90% - Optionally send messages about clean files to SNS

### DIFF
--- a/template.json
+++ b/template.json
@@ -359,7 +359,7 @@
               "/opt/aws-s3-virusscan-master/s3-virusscan.conf": {
                 "content": {"Fn::Join": ["", [
                   "delete: ", {"Ref": "DeleteInfectedFilesParameter"}, "\n",
-                  "reportClean: ", {"Ref": "ReportCleanFilesParameter"}, "\n",
+                  "report_clean: ", {"Ref": "ReportCleanFilesParameter"}, "\n",
                   "region: ", {"Ref": "AWS::Region"}, "\n",
                   "queue: ", {"Ref": "ScanQueue"}, "\n",
                   "topic: ", {"Ref": "FindingsTopic"}, "\n"

--- a/template.json
+++ b/template.json
@@ -38,6 +38,12 @@
       "Default": "true",
       "AllowedValues": ["true", "false"]
     },
+    "ReportCleanFilesParameter": {
+      "Description": "Report successful scan of clean, as well as infected files to the SNS topic",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": ["true", "false"]
+    },
     "BlockDeviceMappingsParameter": {
       "Description": "The size of the volume, in gibibytes (GiBs).",
       "Type": "Number",
@@ -353,6 +359,7 @@
               "/opt/aws-s3-virusscan-master/s3-virusscan.conf": {
                 "content": {"Fn::Join": ["", [
                   "delete: ", {"Ref": "DeleteInfectedFilesParameter"}, "\n",
+                  "reportClean: ", {"Ref": "ReportCleanFilesParameter"}, "\n",
                   "region: ", {"Ref": "AWS::Region"}, "\n",
                   "queue: ", {"Ref": "ScanQueue"}, "\n",
                   "topic: ", {"Ref": "FindingsTopic"}, "\n"

--- a/worker.rb
+++ b/worker.rb
@@ -19,6 +19,26 @@ infected_status = 'infected';
 
 log.info "s3-virusscan started"
 
+def publish_notification(msg,status)
+  log.info msg
+  sns = Aws::SNS::Client.new()
+  sns.publish(
+    topic_arn: conf['topic'],
+    message: msg,
+    subject: "s3-virusscan s3://#{bucket}",
+    message_attributes: {
+      "key" => {
+        data_type: "String",
+        string_value: "s3://#{bucket}/#{key}"
+      },
+      "status" => {
+        data_type: "String",
+        string_value: status
+      }
+    }
+  )
+end
+
 poller.poll do |msg|
   body = JSON.parse(msg.body)
   if body.key?('Records')
@@ -60,22 +80,3 @@ poller.poll do |msg|
   end
 end
 
-def publish_notification(msg,status)
-  log.info msg
-  sns = Aws::SNS::Client.new()
-  sns.publish(
-    topic_arn: conf['topic'],
-    message: msg,
-    subject: "s3-virusscan s3://#{bucket}",
-    message_attributes: {
-      "key" => {
-        data_type: "String",
-        string_value: "s3://#{bucket}/#{key}"
-      },
-      "status" => {
-        data_type: "String",
-        string_value: status
-      }
-    }
-  )
-end

--- a/worker.rb
+++ b/worker.rb
@@ -6,77 +6,93 @@ require 'uri'
 require 'yaml'
 require 'syslog/logger'
 
-log = Syslog::Logger.new 's3-virusscan'
-conf = YAML::load_file(__dir__ + '/s3-virusscan.conf')
 
-Aws.config.update(region: conf['region'])
-s3 = Aws::S3::Client.new()
+class ClamScanWorker
 
-poller = Aws::SQS::QueuePoller.new(conf['queue'])
+  attr_reader :log, :conf, :sns
 
-clean_status = 'clean';
-infected_status = 'infected';
+  CLEAN_STATUS = 'clean'
+  INFECTED_STATUS = 'infected'
 
-log.info "s3-virusscan started"
+  def initialize
+    @log = Syslog::Logger.new 's3-virusscan'
+    @conf = YAML::load_file(__dir__ + '/s3-virusscan.conf')
+    Aws.config.update(region: conf['region'])
+    @sns = Aws::SNS::Client.new()
+  end
 
-def publish_notification(msg,status)
-  log.info msg
-  sns = Aws::SNS::Client.new()
-  sns.publish(
-    topic_arn: conf['topic'],
-    message: msg,
-    subject: "s3-virusscan s3://#{bucket}",
-    message_attributes: {
-      "key" => {
-        data_type: "String",
-        string_value: "s3://#{bucket}/#{key}"
-      },
-      "status" => {
-        data_type: "String",
-        string_value: status
-      }
-    }
-  )
-end
+  def perform
+    log.info "s3-virusscan started"
 
-poller.poll do |msg|
-  body = JSON.parse(msg.body)
-  if body.key?('Records')
-    body['Records'].each do |record|
-      bucket = record['s3']['bucket']['name']
-      key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
-      log.debug "scanning s3://#{bucket}/#{key}..."
-      begin
-        s3.get_object(
-          response_target: '/tmp/target',
-          bucket: bucket,
-          key: key
-        )
-      rescue Aws::S3::Errors::NoSuchKey
-        log.error "s3://#{bucket}/#{key} does no longer exist"
-        next
-      end
-      if system('clamscan /tmp/target')
-        if conf['reportClean']
-          publish_notification("s3://#{bucket}/#{key} is clean",clean_status);
-        else
-          # log only, no notification
-          log.info "s3://#{bucket}/#{key} is clean"
-        end
-      else
-        if conf['delete']
-          publish_notification("s3://#{bucket}/#{key} is infected, deleting...",infected_status);
-          s3.delete_object(
-            bucket: bucket,
-            key: key
-          )
-          log.info "s3://#{bucket}/#{key} was deleted"
-        else
-          publish_notification("s3://#{bucket}/#{key} is infected",infected_status);
+    s3 = Aws::S3::Client.new()
+    poller = Aws::SQS::QueuePoller.new(conf['queue'])
+
+    poller.poll do |msg|
+      body = JSON.parse(msg.body)
+      if body.key?('Records')
+        body['Records'].each do |record|
+          bucket = record['s3']['bucket']['name']
+          key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
+          log.debug "scanning s3://#{bucket}/#{key}..."
+          begin
+            s3.get_object(
+              response_target: '/tmp/target',
+              bucket: bucket,
+              key: key
+            )
+          rescue Aws::S3::Errors::NoSuchKey
+            log.error "s3://#{bucket}/#{key} does no longer exist"
+            next
+          end
+          if system('clamscan /tmp/target')
+            if conf['report_clean']
+              publish_notification(bucket,key,CLEAN_STATUS);
+            else
+              # log only, no notification
+              log.info "s3://#{bucket}/#{key} is clean"
+            end
+          else
+            publish_notification(bucket,key,INFECTED_STATUS);
+            if conf['delete']
+              s3.delete_object(
+                bucket: bucket,
+                key: key
+              )
+              log.info "s3://#{bucket}/#{key} was deleted"
+            end
+          end
+          system('rm /tmp/target')
         end
       end
-      system('rm /tmp/target')
     end
   end
+
+  private
+
+  def publish_notification(bucket,key,status)
+    msg = "s3://#{bucket}/#{key} is #{status}"
+    if conf['delete']
+      msg << ", deleting..."
+    end
+    log.info msg
+    sns.publish(
+      topic_arn: conf['topic'],
+      message: msg,
+      subject: "s3-virusscan s3://#{bucket}",
+      message_attributes: {
+        "key" => {
+          data_type: "String",
+          string_value: key
+        },
+        "status" => {
+          data_type: "String",
+          string_value: status
+        }
+      }
+    )
+  end
+
 end
 
+# do some work
+ClamScanWorker.new.perform

--- a/worker.rb
+++ b/worker.rb
@@ -38,7 +38,7 @@ poller.poll do |msg|
       end
       if system('clamscan /tmp/target')
         if conf['reportClean']
-          publish_notification(""s3://#{bucket}/#{key} is clean",clean_status);
+          publish_notification("s3://#{bucket}/#{key} is clean",clean_status);
         else
           # log only, no notification
           log.info "s3://#{bucket}/#{key} is clean"


### PR DESCRIPTION
Fixes #10

This PR introduces the notion being able to optionally send notifications to the SNS queue for successfully scanned clean files.

At this stage we are looking for feedback on the approach, so the PR is not ready for merge yet (30% feedback - see http://talis.github.io/topics/code-reviews.html & http://lifehacker.com/the-30-percent-rule-and-the-art-of-early-feedback-1619474527). Once the approach is agreed I will test in our own AWS account and complete the PR for 90% feedback.

Functionality questions:
- Should we split the topics - i.e. have one topic for success and another for fail, or are we happy with both style of messages to the same topic?
- Are we happy about the extra message attribute `status` and it's values `clean | infected`?

TODO:
- [x] DRY up the SQS publish code in wrapper.rb
- [x] End to end manual test
