### PR TITLE
Add ability to tag S3 objects with a value of "clean" or "infected" upon successful scan

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,8 @@ Metadata:
       Parameters:
       - DeleteInfectedFiles
       - ReportCleanFiles
+      - TagFiles
+      - TagKey
       - S3BucketRestriction
       - S3ObjectRestriction
     - Label:
@@ -60,6 +62,17 @@ Parameters:
     AllowedValues:
     - true
     - false
+  TagFiles:
+    Description: 'Tag successful scan of clean, as well as infected files'
+    Type: String
+    Default: false
+    AllowedValues:
+    - true
+    - false
+  TagKey:
+    Description: 'S3 object tag key used to specify "clean" or "infected".'
+    Type: String
+    Default: 'clamav-status'
   AutoScalingMinSize:
     Description: 'Min Size for Auto Scaling'
     Type: Number
@@ -519,7 +532,7 @@ Resources:
               clamd: []
               clamav-update: []
             rubygems:
-              aws-sdk: ['2.2.29']
+              aws-sdk: ['2.11.33']
               daemons: ['1.2.4']
               rubysl-securerandom: ['2.0.0']
           files:
@@ -543,7 +556,7 @@ Resources:
 
                 class ClamScanWorker
 
-                  attr_reader :log, :conf, :sns
+                  attr_reader :log, :conf, :sns, :tag_key, :clean_tag_set, :infected_tag_set
 
                   CLEAN_STATUS = 'clean'
                   INFECTED_STATUS = 'infected'
@@ -552,6 +565,9 @@ Resources:
                     @log = Syslog::Logger.new 's3-virusscan'
                     @conf = YAML::load_file(__dir__ + '/s3-virusscan.conf')
                     Aws.config.update(region: conf['region'])
+                    @tag_key = conf['tag_key']
+                    @clean_tag_set = {tag_set: [{key: tag_key, value: CLEAN_STATUS}]}
+                    @infected_tag_set = {tag_set: [{key: tag_key, value: INFECTED_STATUS}]}
                     @sns = Aws::SNS::Client.new()
                   end
 
@@ -589,6 +605,13 @@ Resources:
                                 else
                                   log.debug "s3://#{bucket}/#{key} is clean"
                                 end
+                                if conf['tag_files']
+                                  s3.put_object_tagging({
+                                      bucket: bucket,
+                                      key: key,
+                                      tagging: clean_tag_set
+                                  })
+                                end
                               elsif exitstatus == 1 # Virus(es) found.
                                 publish_notification(bucket, key, INFECTED_STATUS);
                                 if conf['delete']
@@ -597,6 +620,12 @@ Resources:
                                     key: key
                                   )
                                   log.debug "s3://#{bucket}/#{key} was deleted"
+                                elsif conf['tag_files']
+                                  s3.put_object_tagging({
+                                      bucket: bucket,
+                                      key: key,
+                                      tagging: infected_tag_set
+                                  })
                                 end
                               else # An error occured.
                                 raise "s3://#{bucket}/#{key} could not be scanned, clamdscan exit status was #{exitstatus}, retry"
@@ -649,6 +678,8 @@ Resources:
               content: !Sub |
                 delete: ${DeleteInfectedFiles}
                 report_clean: ${ReportCleanFiles}
+                tag_files: ${TagFiles}
+                tag_key: ${TagKey}
                 region: ${AWS::Region}
                 queue: ${ScanQueue}
                 topic: ${FindingsTopic}

--- a/template.yaml
+++ b/template.yaml
@@ -63,14 +63,14 @@ Parameters:
     - true
     - false
   TagFiles:
-    Description: 'Tag successful scan of clean, as well as infected files'
+    Description: 'Tag S3 object upon successful scan accordingly with values of "clean" or "infected" using key specified by TagKey.'
     Type: String
     Default: false
     AllowedValues:
     - true
     - false
   TagKey:
-    Description: 'S3 object tag key used to specify "clean" or "infected".'
+    Description: 'S3 object tag key used to specify values of "clean" or "infected".'
     Type: String
     Default: 'clamav-status'
   AutoScalingMinSize:

--- a/template.yaml
+++ b/template.yaml
@@ -123,6 +123,7 @@ Conditions:
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasNotSSHBastionSecurityGroup: !Equals [!Ref ParentSSHBastionStack, '']
   HasDeleteInfectedFiles: !Equals [!Ref DeleteInfectedFiles, 'true']
+  HasTagFiles: !Equals [!Ref TagFiles, 'true']
   HasSpotPrice: !Not [!Equals [!Ref SpotPrice, '']]
 Mappings:
   RegionMap:
@@ -349,6 +350,22 @@ Resources:
           - 's3:DeleteObject*'
           Resource: !Ref S3ObjectRestriction
       PolicyName: s3delete
+      Roles:
+        - !Ref ScanIAMRole
+  TagObjectPolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: HasTagFiles
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: 's3:PutObjectTagging'
+            Resource: !Ref S3ObjectRestriction
+            Condition:
+              'ForAllValues:StringLike':
+                's3:RequestObjectTagKeys': !Ref TagKey
+      PolicyName: s3objecttag
       Roles:
         - !Ref ScanIAMRole
   ScanIAMPolicySSHAccess:


### PR DESCRIPTION
**Requirement:**
Ability to tag S3 objects upon successful completion of the scan.  Within our application we use the absence of the `clamav-status` key or the fact that key is set to `infected` to block user access to the file.

**Solution:**
I've added 2 parameters to the CloudFormation template `TagFiles` (boolean) and `TagKey` (key to be used for the tag, defaults to `clamav-status`).  If `TagFiles` is set to `true` an additional IAM policy is set that allows for the putting of object tags (via: the [`put_object_tagging`](https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#put_object_tagging-instance_method) method).  This policy respects values set in `S3ObjectRestriction` and only allows for the key specified by `TagKey` to be set.

In order to gain access to the `put_object_tagging` method I had to specify a newer version of the `aws-sdk` gem.

**Result:**
Here's a screenshot of the result in the case of a clean scan:

![clean-tag-set](https://user-images.githubusercontent.com/3768409/38697384-d53c7d7a-3e5f-11e8-8bc3-837113abf390.PNG)



