### PR TITLE
Fix bug publishing notification when no action is taken on infected file

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -836,7 +836,7 @@ Resources:
                                   publish_notification(bucket, key, version, INFECTED_STATUS, TAG_ACTION);
                                 else
                                   $log.debug "s3://#{bucket}/#{key} #{version} is infected"
-                                  publish_notification(bucket, key, version, INFECTED_STATUS, NONE_ACTION);
+                                  publish_notification(bucket, key, version, INFECTED_STATUS, NO_ACTION);
                                 end
                               else # An error occured.
                                 raise "s3://#{bucket}/#{key} #{version} could not be scanned, clamdscan exit status was #{exitstatus}, retry"


### PR DESCRIPTION
When configured to take no action on infected files, the published notification line was attempting to reference `NONE_ACTION` instead of `NO_ACTION`. This resulted in no notification being published in that scenario. Updated reference.