### PR TITLE
Migrate LaunchConfiguration to LaunchTemplate

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1037,7 +1037,6 @@ Resources:
                 - '/etc/cfn/cfn-hup.conf'
                 - '/etc/cfn/hooks.d/cfn-auto-reloader.conf'
     Properties:
-      LaunchTemplateName: ScanLaunchTemplate
       LaunchTemplateData:
         KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
         NetworkInterfaces:
@@ -1055,13 +1054,12 @@ Resources:
         IamInstanceProfile:
           Name: !Ref ScanInstanceProfile
         ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
-        InstanceMarketOptions:
-          !If
-          - HasSpotPrice
-          - MarketType: spot
-            SpotOptions:
-              MaxPrice: !Ref SpotPrice
-          - !Ref AWS::NoValue
+        InstanceMarketOptions: !If
+        - HasSpotPrice
+        - MarketType: spot
+          SpotOptions:
+            MaxPrice: !Ref SpotPrice
+        - !Ref AWS::NoValue
         InstanceType: !Ref InstanceType
         UserData:
           'Fn::Base64': !Sub |

--- a/template.yaml
+++ b/template.yaml
@@ -299,7 +299,9 @@ Resources:
   ScanAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
     Properties:
-      LaunchConfigurationName: !Ref ScanLaunchConfiguration
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ScanLaunchTemplate
+        Version: !GetAtt ScanLaunchTemplate.LatestVersionNumber
       MaxSize: !Ref AutoScalingMaxSize
       MinSize: !Ref AutoScalingMinSize
       VPCZoneIdentifier: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-SubnetsPublic'}]
@@ -476,8 +478,8 @@ Resources:
     Type: 'AWS::Logs::LogGroup'
     Properties:
       RetentionInDays: !Ref LogsRetentionInDays
-  ScanLaunchConfiguration:
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
+  ScanLaunchTemplate:
+    Type: 'AWS::EC2::LaunchTemplate'
     Metadata:
       'AWS::CloudFormation::Init':
         configSets:
@@ -967,8 +969,8 @@ Resources:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
-                path=Resources.ScanLaunchConfiguration.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ScanLaunchConfiguration --region ${AWS::Region}
+                path=Resources.ScanLaunchTemplate.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ScanLaunchTemplate --region ${AWS::Region}
                 runas=root
           commands:
             a_enable_freshclam_cron:
@@ -1035,27 +1037,38 @@ Resources:
                 - '/etc/cfn/cfn-hup.conf'
                 - '/etc/cfn/hooks.d/cfn-auto-reloader.conf'
     Properties:
-      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
-      AssociatePublicIpAddress: true
-      EbsOptimized: false
-      BlockDeviceMappings:
-      - DeviceName: '/dev/xvda'
-        Ebs:
-          VolumeSize: !Ref VolumeSize
-          VolumeType: gp3
-          Encrypted: true
-      IamInstanceProfile: !Ref ScanInstanceProfile
-      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
-      InstanceType: !Ref InstanceType
-      SpotPrice: !If [HasSpotPrice, !Ref SpotPrice, !Ref 'AWS::NoValue']
-      SecurityGroups:
-      - !Ref ScanSecurityGroup
-      UserData:
-        'Fn::Base64': !Sub |
-          #!/bin/bash -ex
-          trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource ScanAutoScalingGroup --region ${AWS::Region}' ERR
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ScanLaunchConfiguration --region ${AWS::Region}
-          /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource ScanAutoScalingGroup --region ${AWS::Region}
+      LaunchTemplateName: ScanLaunchTemplate
+      LaunchTemplateData:
+        KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+        NetworkInterfaces:
+        - DeviceIndex: 0
+          AssociatePublicIpAddress: true
+          Groups:
+          - !Ref ScanSecurityGroup
+        EbsOptimized: false
+        BlockDeviceMappings:
+        - DeviceName: '/dev/xvda'
+          Ebs:
+            VolumeSize: !Ref VolumeSize
+            VolumeType: gp3
+            Encrypted: true
+        IamInstanceProfile:
+          Name: !Ref ScanInstanceProfile
+        ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
+        InstanceMarketOptions:
+          !If
+          - HasSpotPrice
+          - MarketType: spot
+            SpotOptions:
+              MaxPrice: !Ref SpotPrice
+          - !Ref AWS::NoValue
+        InstanceType: !Ref InstanceType
+        UserData:
+          'Fn::Base64': !Sub |
+            #!/bin/bash -ex
+            trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource ScanAutoScalingGroup --region ${AWS::Region}' ERR
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ScanLaunchTemplate --region ${AWS::Region}
+            /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource ScanAutoScalingGroup --region ${AWS::Region}
   ScanSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
**Motivation:**

The following message from AWS has prompted us to migrate from launch configurations to launch templates.

> Amazon EC2 Auto Scaling no longer adds support for new EC2 features to launch configurations and will stop supporting new EC2 instances types after December 31, 2022. We recommend that customers using launch configurations migrate to launch templates.

[Launch template documentation.](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html)

**Solution:**

I've adjusted the CloudFormation template to leverage a launch template instead of a launch configuration. Through manual testing, the changes appear to be working as expected. I tested with and without a `SpotPrice` being specified.